### PR TITLE
add build and push workflow

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -1,0 +1,21 @@
+name: build and push
+on:
+  push:
+    branches:
+      - master
+      - ref/tags/*
+      - feature/*
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: chekout
+        uses: actions/checkout@master
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: assembly_line
+        uses: C-FO/image_assembly_line@master
+        with:
+          image_name: clusterops/kube-node-init

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG ?= 0.1.0
+TAG ?= 0.2.4
 
 dev: TAG=dev-$(shell md5 -q Dockerfile)
 dev:
@@ -8,10 +8,10 @@ dev:
 	helm tiller run tiller-system -- helm upgrade --debug --install --force --set image.tag=$(TAG) --set script=echo node-init-dev charts/kube-node-init
 
 build:
-	docker build -t mumoshu/kube-node-init:$(TAG) .
+	docker build -t clusterops/kube-node-init:$(TAG) .
 
 push:
-	docker push mumoshu/kube-node-init:$(TAG)
+	docker push clusterops/kube-node-init:$(TAG)
 
 repackage-all:
 	scripts/repackage-all.sh || git checkout master


### PR DESCRIPTION
kube-node-init の build and pushがなく、メンテナンスされたリポジトリもなく、workflowがないためとりあえずforkして作りました。assembly_lineを使っています

もうちょっと抽象化したら本線にPRして取り込んでもらったほうが良さそうと思いつつ

関連: https://github.com/C-FO/clusterops/pull/4820